### PR TITLE
Fix: README example didn't compile because source order

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,12 +215,6 @@ func main() {
   {{/each}}
 </div>`
 
-    type Post struct {
-        Author   Person
-        Body     string
-        Comments []Comment
-    }
-
     type Person struct {
         FirstName string
         LastName  string
@@ -229,6 +223,12 @@ func main() {
     type Comment struct {
         Author Person
         Body   string
+    }
+
+    type Post struct {
+        Author   Person
+        Body     string
+        Comments []Comment
     }
 
     ctx := Post{


### PR DESCRIPTION
This example doesn't compile when copied, it appears source order does matter here, so moved the Post struct down so that the example compiles when copied.
