### PR TITLE
Adds struct tag template variable support

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -324,7 +324,11 @@ func (v *evalVisitor) evalField(ctx reflect.Value, fieldName string, exprRoot bo
 			if tField, ok := ctx.Type().FieldByName(expFieldName); ok && (tField.PkgPath == "") {
 				// struct field
 				result = ctx.FieldByIndex(tField.Index)
+				break
 			}
+
+			// attempts to find template variable name as a struct tag
+			result = v.evalFieldStructTag(ctx, fieldName)
 		case reflect.Map:
 			nameVal := reflect.ValueOf(fieldName)
 			if nameVal.Type().AssignableTo(ctx.Type().Key()) {
@@ -385,6 +389,23 @@ func (v *evalVisitor) evalFieldFunc(name string, funcVal reflect.Value, exprRoot
 	}
 
 	return v.callFunc(name, funcVal, options)
+}
+
+// evalFieldStructTag checks for the existence of a struct tag containing the
+// name of the variable in the template. This allows for a template variable to
+// be separated from the field in the struct.
+func (v *evalVisitor) evalFieldStructTag(ctx reflect.Value, n string) reflect.Value {
+	d := reflect.ValueOf(ctx.Interface())
+
+	for i := 0; i < d.NumField(); i++ {
+		ft := d.Type().Field(i)
+		t := ft.Tag.Get("handlebars")
+		if t == n {
+			return d.Field(i)
+		}
+	}
+
+	return reflect.Value{}
 }
 
 // findBlockParam returns node's block parameter

--- a/eval_test.go
+++ b/eval_test.go
@@ -168,6 +168,63 @@ func TestEvalStruct(t *testing.T) {
 	}
 }
 
+func TestEvalStructTag(t *testing.T) {
+	t.Parallel()
+
+	source := `<div class="person">
+	<h1>{{real-name}}</h1>
+	<ul>
+	  <li>City: {{info.location}}</li>
+	  <li>Rug: {{info.[r.u.g]}}</li>
+	  <li>Activity: {{info.activity}}</li>
+	</ul>
+	{{#each other-names}}
+	<p>{{alias-name}}</p>
+	{{/each}}
+</div>`
+
+	expected := `<div class="person">
+	<h1>Lebowski</h1>
+	<ul>
+	  <li>City: Venice</li>
+	  <li>Rug: Tied The Room Together</li>
+	  <li>Activity: Bowling</li>
+	</ul>
+	<p>his dudeness</p>
+	<p>el duderino</p>
+</div>`
+
+	type Alias struct {
+		Name string `handlebars:"alias-name"`
+	}
+
+	type CharacterInfo struct {
+		City     string `handlebars:"location"`
+		Rug      string `handlebars:"r.u.g"`
+		Activity string `handlebars:"not-activity"`
+	}
+
+	type Character struct {
+		RealName string `handlebars:"real-name"`
+		Info     CharacterInfo
+		Aliases  []Alias `handlebars:"other-names"`
+	}
+
+	ctx := Character{
+		"Lebowski",
+		CharacterInfo{"Venice", "Tied The Room Together", "Bowling"},
+		[]Alias{
+			{"his dudeness"},
+			{"el duderino"},
+		},
+	}
+
+	output := MustRender(source, ctx)
+	if output != expected {
+		t.Errorf("Failed to evaluate with struct tag context")
+	}
+}
+
 type TestFoo struct {
 }
 


### PR DESCRIPTION
First off, really great job with this project. Our team has been using it for a couple months and it's been flawless.

We have some shared templates that have such characters as dashes and dots in the middle of the template variable names. For example:

```
foo.bar-baz
foo.[bar.baz]
```

This is along the same lines of segment-literal notation that is denoted under [expressions](http://handlebarsjs.com/expressions.html#basic-blocks). To support this behavior, this work adds the ability to specify a template variable name defined in a struct tag. Here's how a struct would look:

``` go
type Data struct {
  Name string `handlebars:"something-other-than-name"`
}
```

The corresponding template would look like:

``` handlebars
<p>{{something-other-than-name}}</p>
```

This also extends to using a different name for the template variable, similar to JSON and various database implementations, if warranted.

A few things to note:
- It is currently using a struct tag called handlebars, but I'd be fine going with something more specific (i.e. `raymond.name`)
- The current implementation will default to the field name in the struct. If the name of the field doesn't match in the template, this acts as a fallback. I would be fine with switching the order of this logic.

Let me know if you have any other suggestions or questions regarding this work.
