### PR TITLE
Set the current context onto the newIterDataFrame.

### DIFF
--- a/helper.go
+++ b/helper.go
@@ -189,7 +189,11 @@ func (options *Options) NewDataFrame() *DataFrame {
 
 // newIterDataFrame instanciates a new data frame and set iteration specific vars
 func (options *Options) newIterDataFrame(length int, i int, key interface{}) *DataFrame {
-	return options.eval.dataFrame.newIterDataFrame(length, i, key)
+	df := options.eval.dataFrame.newIterDataFrame(length, i, key)
+	// set the current parent context on to the dataframe. if not, it gets lost and
+	// you can't get access to it from with an #each block.
+	df.Set("parent", options.Ctx())
+	return df
 }
 
 //


### PR DESCRIPTION
Currently it is not possible to get access to the "parent" context from a helper inside of an `each` block. This PR solves that problem.

Assumptions:
```go
// assuming this as the context for a template
map[string]interface{}{
  "name": "Mark",
  "items": []string{"item1", "item2"},
}
```

```handlebars
<!-- assuming this template -->
{{#each item as |items|}}
  {{ some_helper }}
{{/each}}
```

Current situation:
```go
// this function no longer has access to the "name" value from the original context.
func someHelper(options *raymond.Options) string {
  return options.Data("name").(string)
}
```

This PR's solution:
```go
// this function can get the "parent" context from the current DataFrame and
// the get access to the information it needs.
func someHelper(options *raymond.Options) string {
  ctx := options.DataFrame().Get("parent").(map[string]interface{})
  return ctx["name"].(string)
}
```

---

This PR does not change the public API. Ideally it would be great to have something like `options.RootContext()` that would return the context that was originally passed in to the parser/renderer.