### PR TITLE
Made submodule url relative

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "mustache"]
 	path = mustache
-	url = git://github.com/mustache/spec.git
+	url = ../../mustache/spec.git


### PR DESCRIPTION
Using a relative path neatly avoids specifying protocol. This will help users who are not able to clone by ssh due f.e. firewall rules.