### PR TITLE
support an optional custom escape

### DIFF
--- a/base_test.go
+++ b/base_test.go
@@ -25,7 +25,7 @@ func launchTests(t *testing.T, tests []Test) {
 		var tpl *Template
 
 		// parse template
-		tpl, err = Parse(test.input)
+		tpl, err = Parse(test.input, nil)
 		if err != nil {
 			t.Errorf("Test '%s' failed - Failed to parse template\ninput:\n\t'%s'\nerror:\n\t%s", test.name, test.input, err)
 		} else {
@@ -91,7 +91,7 @@ func launchErrorTests(t *testing.T, tests []Test) {
 		var tpl *Template
 
 		// parse template
-		tpl, err = Parse(test.input)
+		tpl, err = Parse(test.input, nil)
 		if err != nil {
 			t.Errorf("Test '%s' failed - Failed to parse template\ninput:\n\t'%s'\nerror:\n\t%s", test.name, test.input, err)
 		} else {

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -16,7 +16,7 @@ func BenchmarkArguments(b *testing.B) {
 		"bar": true,
 	}
 
-	tpl := MustParse(source)
+	tpl := MustParse(source, nil)
 	tpl.RegisterHelper("foo", func(a, b, c, d interface{}) string { return "" })
 
 	b.ResetTimer()
@@ -37,7 +37,7 @@ func BenchmarkArrayEach(b *testing.B) {
 		},
 	}
 
-	tpl := MustParse(source)
+	tpl := MustParse(source, nil)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -57,7 +57,7 @@ func BenchmarkArrayMustache(b *testing.B) {
 		},
 	}
 
-	tpl := MustParse(source)
+	tpl := MustParse(source, nil)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -92,7 +92,7 @@ func BenchmarkComplex(b *testing.B) {
 		},
 	}
 
-	tpl := MustParse(source)
+	tpl := MustParse(source, nil)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -112,7 +112,7 @@ func BenchmarkData(b *testing.B) {
 		},
 	}
 
-	tpl := MustParse(source)
+	tpl := MustParse(source, nil)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -133,7 +133,7 @@ func BenchmarkDepth1(b *testing.B) {
 		"foo": "bar",
 	}
 
-	tpl := MustParse(source)
+	tpl := MustParse(source, nil)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -154,7 +154,7 @@ func BenchmarkDepth2(b *testing.B) {
 		"foo": "bar",
 	}
 
-	tpl := MustParse(source)
+	tpl := MustParse(source, nil)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -172,7 +172,7 @@ func BenchmarkObjectMustache(b *testing.B) {
 		},
 	}
 
-	tpl := MustParse(source)
+	tpl := MustParse(source, nil)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -190,7 +190,7 @@ func BenchmarkObject(b *testing.B) {
 		},
 	}
 
-	tpl := MustParse(source)
+	tpl := MustParse(source, nil)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -216,9 +216,9 @@ func BenchmarkPartialRecursion(b *testing.B) {
 		},
 	}
 
-	tpl := MustParse(source)
+	tpl := MustParse(source, nil)
 
-	partial := MustParse(`{{name}}{{#each kids}}{{>recursion}}{{/each}}`)
+	partial := MustParse(`{{name}}{{#each kids}}{{>recursion}}{{/each}}`, nil)
 	tpl.RegisterPartialTemplate("recursion", partial)
 
 	b.ResetTimer()
@@ -238,9 +238,9 @@ func BenchmarkPartial(b *testing.B) {
 		},
 	}
 
-	tpl := MustParse(source)
+	tpl := MustParse(source, nil)
 
-	partial := MustParse(`Hello {{name}}! You have {{count}} new messages.`)
+	partial := MustParse(`Hello {{name}}! You have {{count}} new messages.`, nil)
 	tpl.RegisterPartialTemplate("variables", partial)
 
 	b.ResetTimer()
@@ -263,7 +263,7 @@ func BenchmarkPath(b *testing.B) {
 		},
 	}
 
-	tpl := MustParse(source)
+	tpl := MustParse(source, nil)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -274,7 +274,7 @@ func BenchmarkPath(b *testing.B) {
 func BenchmarkString(b *testing.B) {
 	source := `Hello world`
 
-	tpl := MustParse(source)
+	tpl := MustParse(source, nil)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -287,7 +287,7 @@ func BenchmarkSubExpression(b *testing.B) {
 
 	ctx := map[string]interface{}{}
 
-	tpl := MustParse(source)
+	tpl := MustParse(source, nil)
 	tpl.RegisterHelpers(map[string]interface{}{
 		"echo":   func(v string) string { return "foo " + v },
 		"header": func() string { return "Colors" },
@@ -307,7 +307,7 @@ func BenchmarkVariables(b *testing.B) {
 		"count": 30,
 	}
 
-	tpl := MustParse(source)
+	tpl := MustParse(source, nil)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/escape.go
+++ b/escape.go
@@ -52,10 +52,18 @@ func escape(w writer, s string) error {
 	return err
 }
 
-// Escape escapes special HTML characters.
-//
-// It can be used by helpers that return a SafeString and that need to escape some content by themselves.
-func Escape(s string) string {
+type escapeFunc func(string) string
+
+// Escaper defines an object which can be used to escape strings.
+type Escaper interface {
+	Escape(string) string
+}
+
+// HTMLEscaper is an Escaper which escapes HTML-unsafe characters in strings.
+type HTMLEscaper struct{}
+
+// Escape HTML characters in a string
+func (h HTMLEscaper) Escape(s string) string {
 	if strings.IndexAny(s, escapedChars) == -1 {
 		return s
 	}
@@ -63,3 +71,10 @@ func Escape(s string) string {
 	escape(&buf, s)
 	return buf.String()
 }
+
+var defaultEscaper = HTMLEscaper{}
+
+// Escape escapes special HTML characters.
+//
+// It can be used by helpers that return a SafeString and that need to escape some content by themselves.
+var Escape = HTMLEscaper.Escape

--- a/eval.go
+++ b/eval.go
@@ -712,7 +712,7 @@ func (v *evalVisitor) partialContext(node *ast.PartialStatement) reflect.Value {
 // evalPartial evaluates a partial
 func (v *evalVisitor) evalPartial(p *partial, node *ast.PartialStatement) string {
 	// get partial template
-	partialTpl, err := p.template()
+	partialTpl, err := p.template(v.tpl.opts)
 	if err != nil {
 		v.errPanic(err)
 	}
@@ -804,7 +804,7 @@ func (v *evalVisitor) VisitMustache(node *ast.MustacheStatement) interface{} {
 	str := Str(expr)
 	if !isSafe && !node.Unescaped {
 		// escape html
-		str = Escape(str)
+		str = v.tpl.escape(str)
 	}
 
 	return str

--- a/handlebars/base_test.go
+++ b/handlebars/base_test.go
@@ -41,7 +41,7 @@ func launchTests(t *testing.T, tests []Test) {
 		}
 
 		// parse template
-		tpl, err = raymond.Parse(test.input)
+		tpl, err = raymond.Parse(test.input, nil)
 		if err != nil {
 			t.Errorf("Test '%s' failed - Failed to parse template\ninput:\n\t'%s'\nerror:\n\t%s", test.name, test.input, err)
 		} else {

--- a/handlebars/basic_test.go
+++ b/handlebars/basic_test.go
@@ -633,7 +633,7 @@ func TestBasicErrors(t *testing.T) {
 	expectedError := regexp.QuoteMeta("Invalid path: text/this")
 
 	for _, input := range inputs {
-		_, err = raymond.Parse(input)
+		_, err = raymond.Parse(input, nil)
 		if err == nil {
 			t.Errorf("Test failed - Error expected")
 		}

--- a/partial.go
+++ b/partial.go
@@ -71,11 +71,11 @@ func findPartial(name string) *partial {
 }
 
 // template returns parsed partial template
-func (p *partial) template() (*Template, error) {
+func (p *partial) template(opts *TemplateOptions) (*Template, error) {
 	if p.tpl == nil {
 		var err error
 
-		p.tpl, err = Parse(p.source)
+		p.tpl, err = Parse(p.source, opts)
 		if err != nil {
 			return nil, err
 		}

--- a/raymond.go
+++ b/raymond.go
@@ -6,7 +6,7 @@ package raymond
 // Note that this function call is not optimal as your template is parsed everytime you call it. You should use Parse() function instead.
 func Render(source string, ctx interface{}) (string, error) {
 	// parse template
-	tpl, err := Parse(source)
+	tpl, err := Parse(source, nil)
 	if err != nil {
 		return "", err
 	}
@@ -24,5 +24,5 @@ func Render(source string, ctx interface{}) (string, error) {
 //
 // Note that this function call is not optimal as your template is parsed everytime you call it. You should use Parse() function instead.
 func MustRender(source string, ctx interface{}) string {
-	return MustParse(source).MustExec(ctx)
+	return MustParse(source, nil).MustExec(ctx)
 }

--- a/raymond_test.go
+++ b/raymond_test.go
@@ -11,7 +11,7 @@ func Example() {
 	}
 
 	// parse template
-	tpl := MustParse(source)
+	tpl := MustParse(source, nil)
 
 	// evaluate template with context
 	output := tpl.MustExec(ctx)

--- a/string_test.go
+++ b/string_test.go
@@ -51,7 +51,7 @@ func ExampleSafeString() {
 		return SafeString("<em>FOO BAR</em>")
 	})
 
-	tpl := MustParse("{{em}}")
+	tpl := MustParse("{{em}}", nil)
 
 	result := tpl.MustExec(nil)
 	fmt.Print(result)

--- a/template_test.go
+++ b/template_test.go
@@ -27,7 +27,7 @@ CONTENT[ '
 func TestNewTemplate(t *testing.T) {
 	t.Parallel()
 
-	tpl := newTemplate(sourceBasic)
+	tpl := newTemplate(sourceBasic, nil)
 	if tpl.source != sourceBasic {
 		t.Errorf("Failed to instantiate template")
 	}
@@ -36,7 +36,7 @@ func TestNewTemplate(t *testing.T) {
 func TestParse(t *testing.T) {
 	t.Parallel()
 
-	tpl, err := Parse(sourceBasic)
+	tpl, err := Parse(sourceBasic, nil)
 	if err != nil || (tpl.source != sourceBasic) {
 		t.Errorf("Failed to parse template")
 	}
@@ -52,7 +52,7 @@ func TestClone(t *testing.T) {
 	sourcePartial := `I am a {{wat}} partial`
 	sourcePartial2 := `Partial for the {{wat}}`
 
-	tpl := MustParse(sourceBasic)
+	tpl := MustParse(sourceBasic, nil)
 	tpl.RegisterPartial("p", sourcePartial)
 
 	if (len(tpl.partials) != 1) || (tpl.partials["p"] == nil) {
@@ -85,7 +85,7 @@ func ExampleTemplate_Exec() {
 	}
 
 	// parse template
-	tpl := MustParse(source)
+	tpl := MustParse(source, nil)
 
 	// evaluate template with context
 	output, err := tpl.Exec(ctx)
@@ -106,7 +106,7 @@ func ExampleTemplate_MustExec() {
 	}
 
 	// parse template
-	tpl := MustParse(source)
+	tpl := MustParse(source, nil)
 
 	// evaluate template with context
 	output := tpl.MustExec(ctx)
@@ -124,7 +124,7 @@ func ExampleTemplate_ExecWith() {
 	}
 
 	// parse template
-	tpl := MustParse(source)
+	tpl := MustParse(source, nil)
 
 	// computes private data frame
 	frame := NewDataFrame()
@@ -144,7 +144,7 @@ func ExampleTemplate_PrintAST() {
 	source := "<h1>{{title}}</h1><p>{{#body}}{{content}} and {{@baz.bat}}{{/body}}</p>"
 
 	// parse template
-	tpl := MustParse(source)
+	tpl := MustParse(source, nil)
 
 	// print AST
 	output := tpl.PrintAST()


### PR DESCRIPTION
This adds an option to override the default escaping, allowing you to use handlebars to render things which are not HTML. It both alters the public API—is a **breaking change**—and adds a feature that might not be the common use case for this library, but I wanted to PR these changes against the canonical repo before creating a fork, just in case you thought they would be useful!

This does the following:

* Adds a new `Escaper` interface, which defines an `Escape` method that can be used to escape unsafe text
* Modifies the existing `Escape` into `HTMLEscaper` which satisfies the `Escaper` interface
* Adds a `TemplateOptions` struct, which defines options for a template, such as its `Escaper`
* Adds `TemplateOptions` as an optional parameter to template parsing functions; when `nil`, the old behavior is maintained
* Fixes `escape_tests.go` which had no asserts, and adds a test for the new feature.

Let me know what you think, or maybe if you like the idea but would prefer it implemented in a different way. It won't hurt my feelings if you close this PR; it's an unnecessary addition for most users, changes the public API, and I don't mind maintaining a fork for my purposes.