### PR TITLE
Add a virtual method "length" on slices, arrays, strings to match JS engines

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -364,6 +364,14 @@ func (v *evalVisitor) evalMethod(ctx reflect.Value, name string, exprRoot bool) 
 	}
 
 	if !method.IsValid() {
+		// Special case for "length" for slices, arrays to provide the same behaviour as JavaScript engines
+		// where the "length" method is implicit.
+		if name == "length" {
+			switch ctx.Kind() {
+			case reflect.Slice, reflect.Array:
+				return reflect.ValueOf(ctx.Len()), true
+			}
+		}
 		return zero, false
 	}
 

--- a/eval.go
+++ b/eval.go
@@ -368,7 +368,7 @@ func (v *evalVisitor) evalMethod(ctx reflect.Value, name string, exprRoot bool) 
 		// where the "length" method is implicit.
 		if name == "length" {
 			switch ctx.Kind() {
-			case reflect.Slice, reflect.Array:
+			case reflect.Slice, reflect.Array, reflect.String:
 				return reflect.ValueOf(ctx.Len()), true
 			}
 		}

--- a/eval_test.go
+++ b/eval_test.go
@@ -72,6 +72,20 @@ var evalTests = []Test{
 		nil, nil, nil,
 		"C",
 	},
+	{
+		"length method on a slice, like with JS engines",
+		"Length: {{arr.length}}",
+		map[string]interface{}{"arr": []int{0, 1, 2}},
+		nil, nil, nil,
+		`Length: 3`,
+	},
+	{
+		"length method on an array, like with JS engines",
+		"Length: {{arr.length}}",
+		map[string]interface{}{"arr": [...]int{0, 1, 2, 3}},
+		nil, nil, nil,
+		`Length: 4`,
+	},
 
 	// @todo Test with a "../../path" (depth 2 path) while context is only depth 1
 }

--- a/eval_test.go
+++ b/eval_test.go
@@ -86,6 +86,13 @@ var evalTests = []Test{
 		nil, nil, nil,
 		`Length: 4`,
 	},
+	{
+		"length method on a string, like with JS engines",
+		"Length: {{str.length}}",
+		map[string]interface{}{"str": "abcde"},
+		nil, nil, nil,
+		`Length: 5`,
+	},
 
 	// @todo Test with a "../../path" (depth 2 path) while context is only depth 1
 }


### PR DESCRIPTION
In JavaScript, all arrays have a property `length` that returns the length of an array. Mustache/Handlebars engines implemented in JS provide this method on array values and some templates originally designed with such engines rely on it. Example: https://jsfiddle.net/u5d5adsa/17/

This patch implements `length` for slices and arrays. Template like `Len: {{ x.length }}` now works with data `{ x: [ 1, 2, 3 ] }` => `Len: 3`