### PR TITLE
README: fix rand.Seed usage in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1104,7 +1104,7 @@ For example, that template and context:
 ```go
 source := "I {{feeling}} you"
 
-rand.Seed(time.Now().UTC().UnixNano())
+rand.Seed(time.Now().UnixNano())
 feelings := []string{"hate", "love"}
 
 ctx := map[string]interface{}{
@@ -1197,7 +1197,7 @@ tpl.RegisterPartials(map[string]string{
     "foo": "<span>bar</span>",
     "baz": "<span>bat</span>",
 })
-rand.Seed(time.Now().UTC().UnixNano())
+rand.Seed(time.Now().UnixNano())
 names := []string{"foo", "baz"}
 
 ctx := map[string]interface{}{

--- a/README.md
+++ b/README.md
@@ -1104,11 +1104,11 @@ For example, that template and context:
 ```go
 source := "I {{feeling}} you"
 
+rand.Seed(time.Now().UTC().UnixNano())
+feelings := []string{"hate", "love"}
+
 ctx := map[string]interface{}{
     "feeling": func() string {
-        rand.Seed(time.Now().UTC().UnixNano())
-
-        feelings := []string{"hate", "love"}
         return feelings[rand.Intn(len(feelings))]
     },
 }
@@ -1197,12 +1197,11 @@ tpl.RegisterPartials(map[string]string{
     "foo": "<span>bar</span>",
     "baz": "<span>bat</span>",
 })
+rand.Seed(time.Now().UTC().UnixNano())
+names := []string{"foo", "baz"}
 
 ctx := map[string]interface{}{
     "whichPartial": func() string {
-        rand.Seed(time.Now().UTC().UnixNano())
-
-        names := []string{"foo", "baz"}
         return names[rand.Intn(len(names))]
     },
 }


### PR DESCRIPTION
- Move `rand.Seed` out of lambdas
- use `time.Now().UnixNano()` instead of `time.Now().UTC().UnixNano()` as seed