### PR TITLE
support deep lookup

### DIFF
--- a/handlebars/builtins_test.go
+++ b/handlebars/builtins_test.go
@@ -334,6 +334,45 @@ var builtinsTests = []Test{
 		nil, nil, nil,
 		"",
 	},
+	{
+		"#lookup - should lookup in subexpression",
+		"{{#with (lookup data goodbyes)}}{{abc}}{{/with}}",
+		map[string]interface{}{"goodbyes": "foo", "data": map[string]interface{}{
+			"foo": map[string]string{"abc": "foo1"},
+			"bar": map[string]string{"abc": "bar1"}}},
+		nil, nil, nil,
+		"foo1",
+	},
+	{
+		"#lookup - should lookup array element deeply in subexpression",
+		"{{#each goodbyes}}{{#with (lookup ../data @index)}}{{foo}}{{bar}}{{/with}}{{/each}}",
+		map[string]interface{}{"goodbyes": []int{0, 1}, "data": []map[string]interface{}{
+			{"foo": "baz1", "bar": "bat1"},
+			{"foo": "baz2", "bar": "bat2"}}},
+		nil, nil, nil,
+		"baz1bat1baz2bat2",
+	},
+	{
+		"#lookup - should lookup map element deeply in subexpression",
+		"{{#each goodbyes}}{{#with (lookup ../data .)}}{{foo}}{{bar}}{{/with}}{{/each}}",
+		map[string]interface{}{"goodbyes": []string{"0", "1"}, "data": map[string]interface{}{
+			"0": map[string]string{"foo": "baz1", "bar": "bat1"},
+			"1": map[string]string{"foo": "baz2", "bar": "bat2"}}},
+		nil, nil, nil,
+		"baz1bat1baz2bat2",
+	},
+	{
+		"#lookup - should lookup struct element deeply in subexpression",
+		"{{#each goodbyes}}{{#with (lookup ../data .)}}{{foo}}{{bar}}{{/with}}{{/each}}",
+		map[string]interface{}{"goodbyes": []string{"One", "Two"}, "data": struct {
+			One map[string]string
+			Two map[string]string
+		}{
+			One: map[string]string{"foo": "baz1", "bar": "bat1"},
+			Two: map[string]string{"foo": "baz2", "bar": "bat2"}}},
+		nil, nil, nil,
+		"baz1bat1baz2bat2",
+	},
 }
 
 func TestBuiltins(t *testing.T) {

--- a/helper.go
+++ b/helper.go
@@ -384,7 +384,7 @@ func logHelper(message string) interface{} {
 
 // #lookup helper
 func lookupHelper(obj interface{}, field string, options *Options) interface{} {
-	return Str(options.Eval(obj, field))
+	return options.Eval(obj, field)
 }
 
 // #equal helper


### PR DESCRIPTION
Originally, the lookup helper only return string, so if it looks up and gets a array, map, struct, it returns the map as a string, which does not allow user to use the data in the map.