### PR TITLE
ReplacePartial

### DIFF
--- a/template.go
+++ b/template.go
@@ -136,6 +136,14 @@ func (tpl *Template) addPartial(name string, source string, template *Template) 
 	tpl.partials[name] = newPartial(name, source, template)
 }
 
+// ReplacePartial replaces or create a partial
+func (tpl *Template) ReplacePartial(name string, source string) {
+	tpl.mutex.Lock()
+	defer tpl.mutex.Unlock()
+
+	tpl.partials[name] = newPartial(name, source, nil)
+}
+
 func (tpl *Template) findPartial(name string) *partial {
 	tpl.mutex.RLock()
 	defer tpl.mutex.RUnlock()


### PR DESCRIPTION
I need to replace a partial before Exec (usecase: in dev, want to reload a partial when I edit it)

```
raw := `{{>partial}}`
tpl, _ := raymond.Parse(raw)

tpl.RegisterPartial("partial", "Bloubi")
tpl.MustExec(tpl) // "Bloubi"

tpl.ReplacePartial("partial", "Boulga")
tpl.MustExec(tpl) // "Boulga"
```

This is the code for this :)